### PR TITLE
prefix hip before hip headers

### DIFF
--- a/clients/rider/misc.h
+++ b/clients/rider/misc.h
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
-#include <hip_runtime_api.h>
+#include <hip/hip_runtime_api.h>
 
 #define countOf( arr ) ( sizeof( arr ) / sizeof( arr[ 0 ] ) )
 
@@ -21,7 +21,7 @@ void setupBuffers( std::vector< int > devices,
                      const unsigned numBuffersOut,
                      void *buffersOut[] );
 
-void clearBuffers(   
+void clearBuffers(
                 	void *buffersIn[],
                 	void *buffersOut[] );
 

--- a/clients/samples/fixed-16/fixed-16.cpp
+++ b/clients/samples/fixed-16/fixed-16.cpp
@@ -9,7 +9,8 @@
 #include <iostream>
 #include <fftw3.h>
 
-#include <hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_vector_types.h>
 #include "rocfft.h"
 
 

--- a/clients/samples/transpose_outplace_1024/transpose_outplace_1024.cpp
+++ b/clients/samples/transpose_outplace_1024/transpose_outplace_1024.cpp
@@ -4,7 +4,7 @@
 
 #include <iostream>
 #include <vector>
-#include <hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 #include "rocfft_transpose.h"
 
 
@@ -14,20 +14,20 @@ int main()
     size_t input_row_size = 1024;
     size_t input_col_size = 1024;
     size_t batch_size = 3;
-    
+
     std::cout << "input_row_size = " << input_row_size << ", input_col_size = " << input_col_size << std::endl;
     std::cout << "batch_size = " << batch_size << std::endl;
-    
+
     size_t output_row_size = input_col_size;
     size_t output_col_size = input_row_size;
 
     size_t input_leading_dim_size = input_col_size;
     size_t output_leading_dim_size = output_col_size;
-    
+
     //allocate host memory
     std::vector<float> input_matrix(input_row_size * input_col_size * batch_size);
     std::vector<float> output_matrix(output_row_size * output_col_size * batch_size, 0);
-    
+
     //init the input matrix
     for(int b = 0; b < batch_size; b++)
     {
@@ -35,9 +35,9 @@ int main()
         {
             for(int j = 0; j < input_col_size; j++)
             {
-                input_matrix[b * input_row_size * input_col_size + i * input_col_size + j] = 
+                input_matrix[b * input_row_size * input_col_size + i * input_col_size + j] =
                 (float)(b * input_row_size * input_col_size + i * input_col_size +j);
-            } 
+            }
         }
     }
 
@@ -68,7 +68,7 @@ int main()
        std::cout << "output_matrix_device allocation was successful" << std::endl;
     else
        std::cout << "output_matrix_device allocation was unsuccessful" << std::endl;
-    
+
     //copy data to device
     err = hipMemcpy(input_matrix_device, input_matrix.data(), batch_size * input_row_size * input_col_size * sizeof(float), hipMemcpyHostToDevice);
     if(err == hipSuccess)
@@ -84,7 +84,7 @@ int main()
     std::vector<size_t> out_stride = {1, output_col_size};
     size_t in_dist = input_col_size * input_row_size;
     size_t out_dist = output_col_size * output_row_size;
-    
+
     status = rocfft_transpose_plan_create(&plan, rocfft_transpose_precision_single, rocfft_transpose_array_type_real_to_real, rocfft_transpose_placement_notinplace,
                                  lengths.size(), lengths.data(), in_stride.data(), out_stride.data(), in_dist, out_dist, batch_size, NULL);
     if(status == rocfft_transpose_status_success)
@@ -106,7 +106,7 @@ int main()
        std::cout << "rocfft_transpose_plan_destroy was successful" << std::endl;
     else
        std::cout << "rocfft_transpose_plan_destroy was unsuccessful" << std::endl;
-    
+
     //copy data from device to host
     err = hipMemcpy(output_matrix.data(), output_matrix_device, batch_size * output_row_size * output_col_size * sizeof(float), hipMemcpyDeviceToHost);
     if(err == hipSuccess)

--- a/clients/selftest/basis_vector.h
+++ b/clients/selftest/basis_vector.h
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #define __HIPCC__
-#include <hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 
 enum FftBasisChoice
 {
@@ -32,7 +32,7 @@ class FftBasisVectorMixComplex
 	size_t N[3];
 	size_t L;
 
-	CT *mix;//time domain as input 
+	CT *mix;//time domain as input
 	CT *ref;//freq domain
 	CT *otp;//freq domain produced by the library to be tested against ref
 
@@ -63,8 +63,8 @@ public:
 
 
 		mix = (CT *)malloc(L * B * sizeof(CT));
-		ref = (CT *)malloc(L * B * sizeof(CT));		
-		otp = (CT *)malloc(L * B * sizeof(CT));	
+		ref = (CT *)malloc(L * B * sizeof(CT));
+		otp = (CT *)malloc(L * B * sizeof(CT));
 
 		hipMalloc(&dev, L * B * sizeof(CT));
 	}
@@ -116,7 +116,7 @@ public:
 			bvSpot[q][1] = b;
 			bvSpot[q][2] = c;
 		}
-		
+
 
 		for(size_t h=0; h<B; h++)
 		{
@@ -143,7 +143,7 @@ public:
 
 							T a = (T)cos(dr*(theta0 + theta1 + theta2));
 							T b = (T)sin(dr*(theta0 + theta1 + theta2));
-					
+
 							mix[h*L + idx2*N[1]*N[0] + idx1*N[0] + idx0][0] += (a*c - b*d);
 							mix[h*L + idx2*N[1]*N[0] + idx1*N[0] + idx0][1] += (b*c + a*d);
 						}

--- a/clients/tests/accuracy_test_common.h
+++ b/clients/tests/accuracy_test_common.h
@@ -5,10 +5,12 @@
 #ifndef ROCFFT_ACCURACY_TEST_COMMON_H
 #define ROCFFT_ACCURACY_TEST_COMMON_H
 
+#include <hip/hip_vector_types.h>
+#include <hip/hip_runtime_api.h>
+
 #include <gtest/gtest.h>
 #include <math.h>
 #include <complex>
-#include <hip_runtime.h>
 #include "rocfft_transpose.h"
 
 template<typename T>
@@ -100,7 +102,7 @@ void real_transpose_test(size_t input_row_size, size_t input_col_size, size_t in
 {
     size_t output_row_size = input_col_size;
     size_t output_col_size = input_row_size;
-   
+
     hipError_t err;
     //create device memory
     T *input_matrix_device, *output_matrix_device;
@@ -109,7 +111,7 @@ void real_transpose_test(size_t input_row_size, size_t input_col_size, size_t in
     err = hipMalloc(&output_matrix_device, batch_size * output_row_size * output_leading_dim_size * sizeof(T));
     //copy data to device
     err = hipMemcpy(input_matrix_device, input_matrix, batch_size * input_row_size * input_leading_dim_size * sizeof(T), hipMemcpyHostToDevice);
-    
+
     //create transpose only plan
     rocfft_transpose_status status;
     rocfft_transpose_plan plan = NULL;
@@ -118,10 +120,10 @@ void real_transpose_test(size_t input_row_size, size_t input_col_size, size_t in
     std::vector<size_t> out_stride = {1, output_leading_dim_size};
     size_t in_dist = input_row_size * input_leading_dim_size;
     size_t out_dist = input_col_size * output_leading_dim_size;
-    
+
     status = create_transpose_plan_test<T>(plan, rocfft_transpose_array_type_real_to_real, rocfft_transpose_placement_notinplace, lengths, in_stride, out_stride, in_dist, out_dist, batch_size);
     status = rocfft_transpose_execute(plan, (void**)&input_matrix_device, (void**)&output_matrix_device, NULL);
-    
+
     //destroy plan
     status = rocfft_transpose_plan_destroy(plan);
 
@@ -276,7 +278,7 @@ void complex_planar_to_planar_transpose_test(size_t input_row_size, size_t input
     size_t out_dist = output_row_size * output_leading_dim_size;
 
     status = create_transpose_plan_test<T>(plan, rocfft_transpose_array_type_complex_planar_to_complex_planar, rocfft_transpose_placement_notinplace, lengths, in_stride, out_stride, in_dist, out_dist, batch_size);
-    
+
     T *input_matrix_ptr[2] = {input_matrix_real_device, input_matrix_imag_device};
     T *output_matrix_ptr[2] = {output_matrix_real_device, output_matrix_imag_device};
     status = rocfft_transpose_execute(plan, (void**)input_matrix_ptr, (void**)output_matrix_ptr, NULL);
@@ -310,7 +312,7 @@ void complex_planar_to_interleaved_transpose_test<float>(size_t input_row_size, 
 
     err = hipMalloc(&input_matrix_real_device, batch_size * input_row_size * input_leading_dim_size * sizeof(float));
     err = hipMalloc(&input_matrix_imag_device, batch_size * input_row_size * input_leading_dim_size * sizeof(float));
-    
+
     err = hipMalloc(&output_matrix_device, batch_size * output_row_size * output_leading_dim_size *sizeof(float2));
     //copy data to device
     err = hipMemcpy(input_matrix_real_device, input_matrix_real, batch_size * input_row_size * input_leading_dim_size * sizeof(float), hipMemcpyHostToDevice);
@@ -324,7 +326,7 @@ void complex_planar_to_interleaved_transpose_test<float>(size_t input_row_size, 
     std::vector<size_t> out_stride = {1, output_leading_dim_size};
     size_t in_dist = input_row_size * input_leading_dim_size;
     size_t out_dist = output_row_size * output_leading_dim_size;
-    
+
     status = create_transpose_plan_test<float2>(plan, rocfft_transpose_array_type_complex_planar_to_complex_interleaved, rocfft_transpose_placement_notinplace, lengths, in_stride, out_stride, in_dist, out_dist, batch_size);
 
     float *input_matrix_ptr[2] = {input_matrix_real_device, input_matrix_imag_device};
@@ -398,7 +400,7 @@ void complex_interleaved_to_planar_transpose_test<float>(size_t input_row_size, 
     //create device memory
     float2 *input_matrix_device;
     float *output_matrix_real_device, *output_matrix_imag_device;
-    
+
     err = hipMalloc(&input_matrix_device, batch_size * input_row_size * input_leading_dim_size *sizeof(float2));
 
     err = hipMalloc(&output_matrix_real_device, batch_size * output_row_size * output_leading_dim_size * sizeof(float));
@@ -417,16 +419,16 @@ void complex_interleaved_to_planar_transpose_test<float>(size_t input_row_size, 
     size_t out_dist = output_row_size * output_leading_dim_size;
 
     status = create_transpose_plan_test<float2>(plan, rocfft_transpose_array_type_complex_interleaved_to_complex_planar, rocfft_transpose_placement_notinplace, lengths, in_stride, out_stride, in_dist, out_dist, batch_size);
-    
+
     float *output_matrix_ptr[2] = {output_matrix_real_device, output_matrix_imag_device};
     status = rocfft_transpose_execute(plan, (void**)&input_matrix_device, (void**)output_matrix_ptr, NULL);
-    
+
     err = hipMemcpy(output_matrix_real, output_matrix_real_device, batch_size * output_row_size * output_leading_dim_size * sizeof(float), hipMemcpyDeviceToHost);
     err = hipMemcpy(output_matrix_imag, output_matrix_imag_device, batch_size * output_row_size * output_leading_dim_size * sizeof(float), hipMemcpyDeviceToHost);
 
     //destroy plan
     status = rocfft_transpose_plan_destroy(plan);
-    
+
     hipFree(input_matrix_device);
     hipFree(output_matrix_real_device);
     hipFree(output_matrix_imag_device);

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -29,11 +29,11 @@ bool comparison_type = root_mean_square;
 int main( int argc, char* argv[] )
 {
     // Declare the supported options.
-    po::options_description desc( "clFFT Runtime Test command line options" );
+    po::options_description desc( "rocFFT Runtime Test command line options" );
     desc.add_options()
         ( "help,h",             "produces this help message" )
         ( "verbose,v",          "print out detailed information for the tests" )
-        ( "noVersion",          "Don't print version information from the clFFT library" )
+        ( "noVersion",          "Don't print version information from the rocFFT library" )
         ( "pointwise,p",        "Do a pointwise comparison to determine test correctness (default: use root mean square)" )
         ( "tolerance,t",        po::value< float >( &tolerance )->default_value( 0.001f ),   "tolerance level to use when determining test pass/fail" )
         ( "numRandom,r",        po::value< size_t >( &number_of_random_tests )->default_value( 2000 ),   "number of random tests to run" )

--- a/src/include/hipfft.h
+++ b/src/include/hipfft.h
@@ -5,7 +5,7 @@
 #ifndef __HIPFFT_H__
 #define __HIPFFT_H__
 
-#include <hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 
 #define DLL_PUBLIC __attribute__ ((visibility ("default")))
 
@@ -32,11 +32,11 @@ typedef enum hipfftResult_t {
 }hipfftResult;
 
 typedef enum hipfftType_t {
-    HIPFFT_R2C = 0x2a,  // Real to complex (interleaved) 
-    HIPFFT_C2R = 0x2c,  // Complex (interleaved) to real 
-    HIPFFT_C2C = 0x29,  // Complex to complex (interleaved) 
-    HIPFFT_D2Z = 0x6a,  // Double to double-complex (interleaved) 
-    HIPFFT_Z2D = 0x6c,  // Double-complex (interleaved) to double 
+    HIPFFT_R2C = 0x2a,  // Real to complex (interleaved)
+    HIPFFT_C2R = 0x2c,  // Complex (interleaved) to real
+    HIPFFT_C2C = 0x29,  // Complex to complex (interleaved)
+    HIPFFT_D2Z = 0x6a,  // Double to double-complex (interleaved)
+    HIPFFT_Z2D = 0x6c,  // Double-complex (interleaved) to double
     HIPFFT_Z2Z = 0x69   // Double-complex to double-complex (interleaved)
 }hipfftType;
 
@@ -48,17 +48,17 @@ typedef double hipfftDoubleComplex[2];
 typedef float  hipfftReal;
 typedef double hipfftDoubleReal;
 
-DLL_PUBLIC hipfftResult hipfftPlan1d(hipfftHandle *plan, 
-                                 int nx, 
-                                 hipfftType type, 
+DLL_PUBLIC hipfftResult hipfftPlan1d(hipfftHandle *plan,
+                                 int nx,
+                                 hipfftType type,
                                  int batch /* deprecated - use hipfftPlanMany */);
 
-DLL_PUBLIC hipfftResult hipfftPlan2d(hipfftHandle *plan, 
+DLL_PUBLIC hipfftResult hipfftPlan2d(hipfftHandle *plan,
                                  int nx, int ny,
                                  hipfftType type);
 
-DLL_PUBLIC hipfftResult hipfftPlan3d(hipfftHandle *plan, 
-                                 int nx, int ny, int nz, 
+DLL_PUBLIC hipfftResult hipfftPlan3d(hipfftHandle *plan,
+                                 int nx, int ny, int nz,
                                  hipfftType type);
 
 DLL_PUBLIC hipfftResult hipfftPlanMany(hipfftHandle *plan,
@@ -68,20 +68,20 @@ DLL_PUBLIC hipfftResult hipfftPlanMany(hipfftHandle *plan,
                                    int *onembed, int ostride, int odist,
                                    hipfftType type,
                                    int batch);
-                                   
-DLL_PUBLIC hipfftResult hipfftMakePlan1d(hipfftHandle plan, 
-                                     int nx, 
-                                     hipfftType type, 
+
+DLL_PUBLIC hipfftResult hipfftMakePlan1d(hipfftHandle plan,
+                                     int nx,
+                                     hipfftType type,
                                      int batch, /* deprecated - use hipfftPlanMany */
                                      size_t *workSize);
 
-DLL_PUBLIC hipfftResult hipfftMakePlan2d(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftMakePlan2d(hipfftHandle plan,
                                      int nx, int ny,
                                      hipfftType type,
                                      size_t *workSize);
 
-DLL_PUBLIC hipfftResult hipfftMakePlan3d(hipfftHandle plan, 
-                                     int nx, int ny, int nz, 
+DLL_PUBLIC hipfftResult hipfftMakePlan3d(hipfftHandle plan,
+                                     int nx, int ny, int nz,
                                      hipfftType type,
                                      size_t *workSize);
 
@@ -93,35 +93,35 @@ DLL_PUBLIC hipfftResult hipfftMakePlanMany(hipfftHandle plan,
                                        hipfftType type,
                                        int batch,
                                        size_t *workSize);
-                                      
-DLL_PUBLIC hipfftResult hipfftMakePlanMany64(hipfftHandle plan, 
-                                         int rank, 
+
+DLL_PUBLIC hipfftResult hipfftMakePlanMany64(hipfftHandle plan,
+                                         int rank,
                                          long long int *n,
-                                         long long int *inembed, 
-                                         long long int istride, 
+                                         long long int *inembed,
+                                         long long int istride,
                                          long long int idist,
-                                         long long int *onembed, 
+                                         long long int *onembed,
                                          long long int ostride, long long int odist,
-                                         hipfftType type, 
+                                         hipfftType type,
                                          long long int batch,
                                          size_t * workSize);
 
 DLL_PUBLIC hipfftResult hipfftGetSizeMany64(hipfftHandle plan,
                                         int rank,
                                         long long int *n,
-                                        long long int *inembed, 
+                                        long long int *inembed,
                                         long long int istride, long long int idist,
-                                        long long int *onembed, 
+                                        long long int *onembed,
                                         long long int ostride, long long int odist,
                                         hipfftType type,
                                         long long int batch,
                                         size_t *workSize);
 
-                                         
-                                      
-                                   
-DLL_PUBLIC hipfftResult hipfftEstimate1d(int nx, 
-                                     hipfftType type, 
+
+
+
+DLL_PUBLIC hipfftResult hipfftEstimate1d(int nx,
+                                     hipfftType type,
                                      int batch, /* deprecated - use hipfftPlanMany */
                                      size_t *workSize);
 
@@ -129,7 +129,7 @@ DLL_PUBLIC hipfftResult hipfftEstimate2d(int nx, int ny,
                                      hipfftType type,
                                      size_t *workSize);
 
-DLL_PUBLIC hipfftResult hipfftEstimate3d(int nx, int ny, int nz, 
+DLL_PUBLIC hipfftResult hipfftEstimate3d(int nx, int ny, int nz,
                                      hipfftType type,
                                      size_t *workSize);
 
@@ -140,63 +140,63 @@ DLL_PUBLIC hipfftResult hipfftEstimateMany(int rank,
                                        hipfftType type,
                                        int batch,
                                        size_t *workSize);
-                                     
-DLL_PUBLIC hipfftResult hipfftCreate(hipfftHandle * handle);                                     
 
-DLL_PUBLIC hipfftResult hipfftGetSize1d(hipfftHandle handle, 
-                                    int nx, 
-                                    hipfftType type, 
+DLL_PUBLIC hipfftResult hipfftCreate(hipfftHandle * handle);
+
+DLL_PUBLIC hipfftResult hipfftGetSize1d(hipfftHandle handle,
+                                    int nx,
+                                    hipfftType type,
                                     int batch, /* deprecated - use hipfftGetSizeMany */
                                     size_t *workSize );
-                                                                         
-DLL_PUBLIC hipfftResult hipfftGetSize2d(hipfftHandle handle, 
+
+DLL_PUBLIC hipfftResult hipfftGetSize2d(hipfftHandle handle,
                                     int nx, int ny,
                                     hipfftType type,
                                     size_t *workSize);
 
 DLL_PUBLIC hipfftResult hipfftGetSize3d(hipfftHandle handle,
-                                    int nx, int ny, int nz, 
+                                    int nx, int ny, int nz,
                                     hipfftType type,
                                     size_t *workSize);
 
-DLL_PUBLIC hipfftResult hipfftGetSizeMany(hipfftHandle handle, 
+DLL_PUBLIC hipfftResult hipfftGetSizeMany(hipfftHandle handle,
                                       int rank, int *n,
                                       int *inembed, int istride, int idist,
                                       int *onembed, int ostride, int odist,
                                       hipfftType type, int batch, size_t *workArea);
-                                     
+
 DLL_PUBLIC hipfftResult hipfftGetSize(hipfftHandle handle, size_t *workSize);
-                                               
+
 DLL_PUBLIC hipfftResult hipfftSetWorkArea(hipfftHandle plan, void *workArea);
 
 DLL_PUBLIC hipfftResult hipfftSetAutoAllocation(hipfftHandle plan, int autoAllocate);
 
-DLL_PUBLIC hipfftResult hipfftExecC2C(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecC2C(hipfftHandle plan,
                                   hipfftComplex *idata,
                                   hipfftComplex *odata,
                                   int direction);
 
-DLL_PUBLIC hipfftResult hipfftExecR2C(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecR2C(hipfftHandle plan,
                                   hipfftReal *idata,
                                   hipfftComplex *odata);
 
-DLL_PUBLIC hipfftResult hipfftExecC2R(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecC2R(hipfftHandle plan,
                                   hipfftComplex *idata,
                                   hipfftReal *odata);
 
-DLL_PUBLIC hipfftResult hipfftExecZ2Z(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecZ2Z(hipfftHandle plan,
                                   hipfftDoubleComplex *idata,
                                   hipfftDoubleComplex *odata,
                                   int direction);
 
-DLL_PUBLIC hipfftResult hipfftExecD2Z(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecD2Z(hipfftHandle plan,
                                   hipfftDoubleReal *idata,
                                   hipfftDoubleComplex *odata);
 
-DLL_PUBLIC hipfftResult hipfftExecZ2D(hipfftHandle plan, 
+DLL_PUBLIC hipfftResult hipfftExecZ2D(hipfftHandle plan,
                                   hipfftDoubleComplex *idata,
                                   hipfftDoubleReal *odata);
-                                  
+
 
 // utility functions
 DLL_PUBLIC hipfftResult hipfftSetStream(hipfftHandle plan,

--- a/src/library/internal_include/rocfft_transpose_kernel.h
+++ b/src/library/internal_include/rocfft_transpose_kernel.h
@@ -4,7 +4,7 @@
 
 #ifndef __ROCFFT_TRANSPOSE_KERNEL_H__
 #define __ROCFFT_TRANSPOSE_KERNEL_H__
-#include "hip_runtime.h"
+#include <hip/hip_runtime.h>
 
 //defined in rocfft_transpose_kernel.cu
 template<typename T, int micro_tile_col_size, int micro_tile_row_size, int wg_col_size, int wg_row_size>
@@ -16,9 +16,9 @@ __global__ void transpose_kernel_outplace_check_boundary(hipLaunchParm lp, T *in
 
 //defined in rocfft_transpose_complex_kernel.cu
 template<typename T, int micro_tile_col_size, int micor_tile_row_size, int wg_col_size, int wg_row_size>
-__global__ void transpose_kernel_outplace_complex_planar_to_complex_planar(hipLaunchParm lp, 
-                                                                           T *input_matrix_real, 
-									   T *input_matrix_imag, 
+__global__ void transpose_kernel_outplace_complex_planar_to_complex_planar(hipLaunchParm lp,
+                                                                           T *input_matrix_real,
+									   T *input_matrix_imag,
 									   T *output_matrix_real,
 									   T *output_matrix_imag,
 		              						   size_t input_row_size,

--- a/src/library/rocfft_hip.h
+++ b/src/library/rocfft_hip.h
@@ -7,7 +7,7 @@
 
 #define __HIPCC__
 
-#include <hip_runtime.h>
+#include <hip/hip_runtime.h>
 
 #endif // __ROCFFT_HIP_H__
 


### PR DESCRIPTION
resolves build error in rocm-1.2

Summary of proposed changes:
-  change "hip_runtime.h" -> "hip_runtime_api.h" wherever applies. 
- prefix /hip/ before hip headers as required in rocm-1.3 
- 

