### PR TITLE
Fixing cmakefile to honor user provided CMAKE_BUILD_TYPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 tags
 .tags
 .*.swp
+
+# Visual Studio Code
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ endif( )
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
-if( NOT CMAKE_CONFIGURATION_TYPES )
-  set( CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE )
+if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE )
 endif()
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node('rocm-1.3 && fiji')
         stage("unit tests") {
           sh '''
               cd clients-build/tests-build/staging
-              ./rocfft-test-correctness-d --gtest_output=xml
+              ./rocfft-test-correctness --gtest_output=xml
           '''
           junit 'clients-build/tests-build/staging/*.xml'
         }
@@ -44,9 +44,9 @@ node('rocm-1.3 && fiji')
         stage("rider") {
           sh '''
               cd clients-build/rider-build/staging
-              ./rocfft-rider-d -x 16
-              ./rocfft-rider-d -x 256
-              ./rocfft-rider-d -x 1024
+              ./rocfft-rider -x 16
+              ./rocfft-rider -x 256
+              ./rocfft-rider -x 1024
           '''
         }
 


### PR DESCRIPTION
Summary of proposed changes:
-  Fix build files to properly build both debug and release binaries


The prior behavior always built debug binaries
ignoring visual studio code metadata directories